### PR TITLE
Fix windows bug in determining local timezone

### DIFF
--- a/nostalgia/times.py
+++ b/nostalgia/times.py
@@ -1,13 +1,12 @@
 from pytz import timezone
-from pytz.reference import Local
+import tzlocal
 from metadate import parse_date, Units
 from datetime import datetime
 from dateutil.parser import parse
 from dateutil.relativedelta import relativedelta
 import dateutil
 
-# tz = timezone('Europe/Amsterdam')
-tz = timezone(Local.tzname(datetime.now()))
+tz = tzlocal.get_localzone()
 utc = timezone('UTC')
 
 

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
         "pyarrow",
         "tldextract",
         "diskcache",
+        "tzlocal",
         # "lxml",  # web_history
         # "diskcache",  # web_history
         # "auto_extract",  # web_history


### PR DESCRIPTION
* New dependency -- tzlocal


Note that this also depends on my other pull request #9 

See https://stackoverflow.com/a/16157307 for a discussion of pytz's issues getting the local timezone on Windows.  The `tzlocal` package fixes the issue.

_______________



## Checks

* `tzlocal.get_localzone` returns a timezone object
* For me (on the east coast of the US), `get_localzone() == timezone("America/New_York")` is True