### PR TITLE
fix nostalgia_data folder permissions to be 700

### DIFF
--- a/nostalgia/file_caching.py
+++ b/nostalgia/file_caching.py
@@ -75,7 +75,7 @@ def check_seen(name, value):
 
 def make_path(name):
     dir_name = os.path.expanduser("~/nostalgia_data/dfs/")
-    just.mkdir(dir_name, 0x700)
+    just.mkdir(dir_name, 0o700)
     return dir_name + slugify(name)
 
 


### PR DESCRIPTION
The issue was that it set really weird file permissions because of a mistake in notation. Used `0x700` which should have been `0o700`. 