### PR TITLE
Mail source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,5 @@ __pycache__/
 .coverage
 .coverage.*
 .coveralls.yml
-*.env
+.vscode
+*.env.vscode

--- a/nostalgia/sources/email/README.md
+++ b/nostalgia/sources/email/README.md
@@ -1,0 +1,40 @@
+# E-Mail source
+
+This source is fed by connecting to an e-mail account via IMAP.
+
+It expects the following environment variables to be set:
+
+- `IMAP_HOSTNAME` the IMAP hostname, e.g. `imap.kolabnow.com`
+- `IMAP_USERNAME` which is often your mail address
+- `IMAP_PASSWORD` the password you log in with
+
+You might want to store the password in a safe like KeePassXC.
+On GNU/Linux, you can write a small script to automate the task of setting
+those variables for you:
+
+```sh
+export IMAP_HOSTNAME="imap.kolabnow.com"
+export IMAP_USERNAME="me@kolabnow.com"
+keepassxc-cli clip ~/path/to/passwords.kdbx email_entry  # Unlock KeePassXC
+export IMAP_PASSWORD="$(xclip -sel clipboard -o)"
+echo "Got ya" | xclip -sel clipboard
+```
+
+To download it for ingestion, run the following code (may take a while):
+
+```py
+from nostalgia.sources.email import Email
+
+Email.download()
+```
+
+Now, add the following lines to your `~/nostalgia_data/nostalgia_entry.py`:
+
+```py
+from nostalgia.sources.email import Email
+
+email = Email.load()
+```
+
+Now, you can start a Nostalgia Timeline and inspect your mails.
+Enjoy!

--- a/nostalgia/sources/email/__init__.py
+++ b/nostalgia/sources/email/__init__.py
@@ -25,7 +25,7 @@ class Email(NDF):
     @classmethod
     def handle_dataframe_per_file(cls, data, fname):
         if data.empty:
-            return None
+            return pd.DataFrame(columns=["text"])
 
         data["subject"] = data["subject"].astype(str)
         data["to"] = data["to"].astype(str)

--- a/nostalgia/sources/email/__init__.py
+++ b/nostalgia/sources/email/__init__.py
@@ -1,0 +1,50 @@
+import os
+
+import dotenv
+import pandas as pd
+from nostalgia.ndf import NDF
+from nostalgia.sources.email.export import ImapExport
+
+dotenv.load_dotenv(".env")
+dotenv.load_dotenv("email/.env")
+
+
+class Email(NDF):
+    me = []
+    vendor = "email"
+
+    @classmethod
+    def download(cls):
+        hostname = os.environ["IMAP_HOSTNAME"]
+        username = os.environ["IMAP_USERNAME"]
+        password = os.environ["IMAP_PASSWORD"]
+
+        imap_export = ImapExport(hostname, username, password)
+        imap_export.walk_folders()
+
+    @classmethod
+    def handle_dataframe_per_file(cls, data, fname):
+        if data.empty:
+            return None
+
+        data["subject"] = data["subject"].astype(str)
+        data["to"] = data["to"].astype(str)
+
+        data["sender"] = data["from"].str.extract("<([^>]+)>")
+        data.loc[data["sender"].isnull(), "sender"] = data[data["sender"].isnull()]["from"].str.strip('"')
+        data["sent"] = data.sender.str.contains("|".join(cls.me), na=False)
+
+        data["receiver"] = data["to"].str.extract("<([^>]+)>")
+        data.loc[data["receiver"].isnull(), "receiver"] = data[data["receiver"].isnull()]["to"].str.strip('"')
+        data["received"] = data.receiver.str.contains("|".join(cls.me), na=False)
+
+        data["timestamp"] = pd.to_datetime(data["sent_date"], utc=True)
+        cls.save_df(data)
+        return data
+
+    @classmethod
+    def load(cls, nrows=None, from_cache=True, **kwargs):
+        file_glob = "~/nostalgia_data/input/imap/**/*.json"
+        dfs = [cls.load_dataframe_per_json_file(file_glob, nrows=nrows)]
+        dfs = [x for x in dfs if not x.empty]
+        return cls(pd.concat(dfs))

--- a/nostalgia/sources/email/__init__.py
+++ b/nostalgia/sources/email/__init__.py
@@ -44,7 +44,7 @@ class Email(NDF):
 
     @classmethod
     def load(cls, nrows=None, from_cache=True, **kwargs):
-        file_glob = "~/nostalgia_data/input/imap/**/*.json"
+        file_glob = "~/nostalgia_data/input/imap/**/**/*.json"
         dfs = [cls.load_dataframe_per_json_file(file_glob, nrows=nrows)]
         dfs = [x for x in dfs if not x.empty]
         return cls(pd.concat(dfs))

--- a/nostalgia/sources/email/export.py
+++ b/nostalgia/sources/email/export.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import re
 
 import just
 from imap_tools import MailBox
@@ -25,7 +26,9 @@ class ImapExport(object):
         self.root = just.make_path("~/nostalgia_data/input/imap")
 
     def filename(self, *args):
-        return os.path.join(self.root, self.hostname, *args)
+        hostname = self._get_valid_filename(self.hostname)
+        email_alias = self._get_valid_filename(self.username.split("@")[0])
+        return os.path.join(self.root, hostname, email_alias, *args)
 
     def walk_folder(self, mailbox, folder_name):
         mails = []
@@ -46,7 +49,9 @@ class ImapExport(object):
         with MailBox(self.hostname).login(self.username, self.password) as mailbox:
             for folder in mailbox.folder.list():
                 folder_name = folder["name"]
-                filename = self.filename("{}.json".format(folder_name.lower()))
+                filename = self.filename("{}.json".format(
+                    self._get_valid_filename(folder_name.lower())
+                ))
 
                 if not os.path.isfile(filename):
                     log.info("Downloading {}".format(filename))
@@ -54,6 +59,11 @@ class ImapExport(object):
                     self.write(filename, mails)
                 else:
                     log.info("Cached {}".format(filename))
+
+    # Inspired by https://github.com/django/django/blob/796be5901a67da44e251e092641682cb2d778176/django/utils/text.py#L221-L232
+    def _get_valid_filename(self, raw_filename):
+        s = str(raw_filename).strip().replace(" ", "_")
+        return re.sub(r"(?u)[^-\w.]", "", s)
 
     def _validate_constructor_arguments(self, hostname, username, password):
         if hostname is None:

--- a/nostalgia/sources/email/export.py
+++ b/nostalgia/sources/email/export.py
@@ -1,0 +1,66 @@
+import json
+import logging
+import os
+
+import just
+from imap_tools import MailBox
+
+log = logging.getLogger(__name__)
+
+
+class ImapExport(object):
+    @staticmethod
+    def write(filename, data):
+        dirname = os.path.dirname(filename)
+        os.makedirs(dirname, exist_ok=True)
+        with open(filename, "w") as f:
+            f.write(json.dumps(data, indent=2, sort_keys=True))
+
+    def __init__(self, hostname, username, password):
+        self._validate_constructor_arguments(hostname, username, password)
+        self.hostname = hostname
+        self.username = username
+        self.password = password
+
+        self.root = just.make_path("~/nostalgia_data/input/imap")
+
+    def filename(self, *args):
+        return os.path.join(self.root, self.hostname, *args)
+
+    def walk_folder(self, mailbox, folder_name):
+        mails = []
+        mailbox.folder.set(folder_name)
+        for msg in mailbox.fetch(mark_seen=False):
+            mails.append(
+                {
+                    "from": msg.from_,
+                    "to": msg.to,
+                    "subject": msg.subject,
+                    "text": msg.text,
+                    "sent_date": msg.date.isoformat(),
+                }
+            )
+        return mails
+
+    def walk_folders(self):
+        with MailBox(self.hostname).login(self.username, self.password) as mailbox:
+            for folder in mailbox.folder.list():
+                folder_name = folder["name"]
+                filename = self.filename("{}.json".format(folder_name.lower()))
+
+                if not os.path.isfile(filename):
+                    log.info("Downloading {}".format(filename))
+                    mails = self.walk_folder(mailbox, folder_name)
+                    self.write(filename, mails)
+                else:
+                    log.info("Cached {}".format(filename))
+
+    def _validate_constructor_arguments(self, hostname, username, password):
+        if hostname is None:
+            raise TypeError("Missing hostname")
+
+        if username is None:
+            raise TypeError("Missing username")
+
+        if password is None:
+            raise TypeError("Missing password")

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup(
         # extras
         "nostalgia_chrome",
         "nostalgia_fitbit",
+        "imap-tools",
     ],
     package_data={
         # If any package contains *.txt or *.rst files, include them:


### PR DESCRIPTION
This introduces a new dependency (`imap-tools`), which seems to be maintained and covers most of low-level IMAP stuff.

When running the code on my own account, I had one or two errors raised, which warrants further inspection.
Most of my emails could be ingested, though.

Do you think, it makes sense to create a subdirectory under the hostname for the alias part of an email account?
After all, a user could have more than one account at that email provider.

What about sanitizing directories? For example, I have some folders containing an `@`.
Is there a utility I can already use? (Otherwise I go with a Regular Expression).

The implementation is inspired by GMail and FitBit sources.

Feedback welcome :-)